### PR TITLE
Fix: sitemap - delete ~/post/

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -18,11 +18,6 @@
   <priority>0.70</priority>
 </url>
 <url>
-  <loc>https://www.rodu.co.kr/post/</loc>
-  <lastmod>2024-03-29T06:19:14+00:00</lastmod>
-  <priority>0.60</priority>
-</url>
-<url>
   <loc>https://www.rodu.co.kr/posts/</loc>
   <lastmod>2024-03-29T06:19:14+00:00</lastmod>
   <priority>0.60</priority>


### PR DESCRIPTION
## 작업내용
- sitemap - delete ~/post/
- sitemap 의 ~/post/ 는 게시물 비밀번호를 입력하고 들어가야 하기 때문에 해당 부분은 삭제하였습니다. 
<br>